### PR TITLE
[Correction] Using USEEIOv2 emission factor, and revise categorization logics

### DIFF
--- a/orchestrator/assets/business_travel.py
+++ b/orchestrator/assets/business_travel.py
@@ -139,27 +139,6 @@ def annual_cpi_index():
     compute_kind="python",
     group_name="raw",
 )
-def expense_category_mapper(dhub: ResourceParam[DataHubResource]):
-    """This asset ingest the expense_type_to_category.json from the Data Hub"""
-    project_id = dhub.get_project_id("Scope3 Business Travel")
-    logger.info(f"Found project id: {project_id}!")
-    download_links = dhub.search_files_from_project(project_id, "expense_type_to_category.json")
-    if download_links is None:
-        logger.info("No download links found!")
-        return pd.DataFrame()
-    response = requests.get(download_links[0], timeout=10)
-    if response.status_code == 200:
-        payload = json.loads(response.text)
-    mapper = {v: key for key, value in payload.items() for v in value}
-    df = pd.DataFrame(list(mapper.items()), columns=["type", "category"])
-    return df
-
-
-@asset(
-    io_manager_key="postgres_replace",
-    compute_kind="python",
-    group_name="raw",
-)
 def expense_emission_mapper(dhub: ResourceParam[DataHubResource]):
     """This asset ingest the expense_type_to_emissions.json from the Data Hub"""
     project_id = dhub.get_project_id("Scope3 Business Travel")
@@ -174,24 +153,6 @@ def expense_emission_mapper(dhub: ResourceParam[DataHubResource]):
     mapper = {v: key for key, value in payload.items() for v in value}
     df = pd.DataFrame(list(mapper.items()), columns=["expense_type", "emission_category"])
     return df
-
-
-@asset(
-    io_manager_key="postgres_replace",
-    compute_kind="python",
-    group_name="raw",
-)
-def mode_co2_mapper(dhub: ResourceParam[DataHubResource]):
-    """This asset ingest the transport_co2_factors.csv from the Data Hub"""
-    project_id = dhub.get_project_id("Scope3 Business Travel")
-    logger.info(f"Found project id: {project_id}!")
-    download_links = dhub.search_files_from_project(project_id, "transport_co2_factors.csv")
-    if download_links is None:
-        logger.info("No download links found!")
-        return pd.DataFrame()
-    mapper = pd.read_csv(download_links[0])
-    mapper = mapper.rename(columns={"Transport Mode": "transport_mode", "CO2 Factor": "CO2_factor"})
-    return mapper
 
 
 @asset(

--- a/warehouse/models/sources.yml
+++ b/warehouse/models/sources.yml
@@ -138,6 +138,27 @@ sources:
           - name: Supply Chain Emission Factors without Margins
           - name: Margins of Supply Chain Emission Factors
           - name: Supply Chain Emission Factors with Margins
+            description: "eCO2 emission factor in kg/$ of NAICSv1.2 (2021 dollars)"
+      - name: emission_factor_useeio_v2
+        description: "USEEIO_v2 The US Environmentally-Extended Input-Output Model"
+        meta:
+          dagster:
+            asset_key: ["emission_factor_useeio_v2"]
+        columns:
+          - name: ID
+            description: "USEEIO code with region"
+            tests:
+              - unique
+          - name: emission_factor
+            description: "eCO2 emission factor in kg/$ from USEEIOv2.0 (2012 dollars)"
+          - name: Name
+            description: "USEEIO description"
+          - name: Code
+            description: "USEEIO Code"
+          - name: Category
+            description: "USEEIO Category"
+          - name: Description
+            description: "BEA code and name"
       - name: historical_waste_recycle
         description: "Waste recycle data from 2010 to 2023 June"
         meta:

--- a/warehouse/models/sources.yml
+++ b/warehouse/models/sources.yml
@@ -54,17 +54,6 @@ sources:
             description: "Cost Collector ID effective since"
           - name: last_update
             description: "Date of last update"
-      - name: expense_category_mapper
-        description: "Mapping database for expense type to larger categories"
-        meta:
-          dagster:
-            asset_key: ["expense_category_mapper"]
-        columns:
-          - name: type
-          - name: category
-            description: "Larger expense group"
-            tests:
-              - not_null
       - name: expense_emission_mapper
         description: "Mapping database for expense type to transport mode required for CO2 factor matching"
         meta:
@@ -76,17 +65,6 @@ sources:
             description: "Larger GHG emission group"
             tests:
               - not_null
-      - name: mode_co2_mapper
-        description: "Mapping dictionary for CO2 factor from transport mode"
-        meta:
-          dagster:
-            asset_key: ["mode_co2_mapper"]
-        columns:
-          - name: transport_mode
-            tests:
-              - unique
-          - name: CO2_factor
-            description: "CO2 emission factor based on transport mode"
       - name: construction_expense
         description: "Construction expense data from VPCSS"
         meta:

--- a/warehouse/models/staging/schema.yml
+++ b/warehouse/models/staging/schema.yml
@@ -19,7 +19,7 @@ models:
       - name: cal_year
         description: Expense record year
       - name: inflated_exp_amount
-        description: Adjusted by the latest annual CPI index
+        description: Adjusted to 2012 dollar using annual CPI index
       - name: dlc_name
         description: Department, Lab and Center name
       - name: school_area
@@ -35,7 +35,7 @@ models:
           - accepted_values:
               values: ['misc.', 'housing', 'meals', 'car', 'train', 'ferry', 'air']
       - name: co2_factor
-        description: CO2 emission factor
+        description: CO2 emission factor in kg/$ from USEEIO_v2
       - name: mtco2
         description: CO2 emission in megatons
   - name: stg_cost_object_rollup

--- a/warehouse/models/staging/schema.yml
+++ b/warehouse/models/staging/schema.yml
@@ -19,7 +19,7 @@ models:
       - name: cal_year
         description: Expense record year
       - name: inflated_exp_amount
-        description: Adjusted to 2012 dollar using annual CPI index
+        description: Adjusted to 2023 dollar using annual CPI index
       - name: dlc_name
         description: Department, Lab and Center name
       - name: school_area
@@ -35,7 +35,7 @@ models:
           - accepted_values:
               values: ['misc.', 'housing', 'meals', 'car', 'train', 'ferry', 'air']
       - name: co2_factor
-        description: CO2 emission factor in kg/$ from USEEIO_v2
+        description: CO2 emission factor in kg/$ from USEEIO_v2 using 2012 dollars
       - name: mtco2
         description: CO2 emission in megatons
   - name: stg_cost_object_rollup

--- a/warehouse/models/staging/stg_travel_spending.sql
+++ b/warehouse/models/staging/stg_travel_spending.sql
@@ -40,10 +40,12 @@ attached AS (
         ON l.cal_year = cpi.year
 ),
 
+-- Maybe still display the Most current Dollar amount, but use a different column fo Emission Calculation
 adjusted AS (
     SELECT
         transaction_id,
-        expense_amount * (SELECT value FROM target_cpi) / src AS inflated_exp_amount,
+        expense_amount * (SELECT value FROM target_cpi) / src AS inflated_exp_2012,
+        expense_amount * (SELECT value FROM current_cpi) / src AS inflated_exp_amount,
         cal_year,
         fiscal_year,
         expense_amount,
@@ -88,7 +90,7 @@ ef AS (
     SELECT
         CASE
             WHEN "Code" = '721000' THEN 'housing'
-            WHEN "Code" = '311990' THEN 'meals'
+            WHEN "Code" = '722211' THEN 'meals'
             WHEN "Code" = '481000' THEN 'air'
             WHEN "Code" = '482000' THEN 'train'
             WHEN "Code" = '483000' THEN 'ferry'
@@ -97,7 +99,7 @@ ef AS (
         END AS transport_mode,
         emission_factor
     FROM {{ source('raw', 'emission_factor_useeio_v2') }}
-    WHERE "Code" IN ('721000', '311990', '481000', '482000', '483000', '485000')
+    WHERE "Code" IN ('721000', '722211', '481000', '482000', '483000', '485000')
 ),
 
 factor AS (
@@ -136,5 +138,5 @@ SELECT
     c.expense_group,
     c.transport_mode,
     c.co2_factor,
-    c.co2_factor * c.inflated_exp_amount / 1000 AS mtco2
+    c.co2_factor * c.inflated_exp_2012 / 1000 AS mtco2
 FROM cat AS c


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] :bug: Bug Fix
- [x] :memo: Documentation Update
- [x] :computer: Code Refactor
- [x] :mag: Test

## Describe your changes
* Correct the travel_spending models to adjust emission factors to 2012 dollars
* Retire expense_group mapping table using `transport_mode` instead
* Retire co2_emission mapping data using emission factors directly from USEEIOv2 table, shared with Construction assets

## Tests
* Unit tests passed
* Local materializations

## Documentation
* Update USEEIOv2 table
* Retire tables

## Screenshots
![image](https://github.com/mit-sustainability/basin/assets/7747527/e3d0bf88-13e7-4821-9e39-e9016c17b5a7)

## What gif best describes this PR or how it makes you feel?
<img src="https://media2.giphy.com/media/ksE4eFvxZM3oyaFEVo/giphy.gif"/>