### PR TITLE
[Patch] Commuting assets new parameters

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -22,14 +22,14 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 vars:
   car_speed: 21
-  t_speed: 15
+  t_speed: 20
   rail_speed: 40
   intercity_speed: 125
   bus_speed: 12
   t_ratio: 0.5
-  bus_ratio: 0.19
-  rail_ratio: 0.3
-  intercity_ratio: 0.02
+  bus_ratio: 0.14
+  rail_ratio: 0.35
+  intercity_ratio: 0.01
   car_share_ratio: 0.4
   van_share_ratio: 0.2
 

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -22,9 +22,16 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 vars:
   car_speed: 21
-  transit_speed: 25 # consider T speed, and average of Commuter rail
-  rail_speed: 125
+  t_speed: 15
+  rail_speed: 40
+  intercity_speed: 125
   bus_speed: 12
+  t_ratio: 0.5
+  bus_ratio: 0.19
+  rail_ratio: 0.3
+  intercity_ratio: 0.02
+  car_share_ratio: 0.4
+  van_share_ratio: 0.2
 
 
 models:

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -22,7 +22,7 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 vars:
   car_speed: 21
-  transit_speed: 65
+  transit_speed: 25 # consider T speed, and average of Commuter rail
   rail_speed: 125
   bus_speed: 12
 

--- a/warehouse/models/final/commuting_emission.sql
+++ b/warehouse/models/final/commuting_emission.sql
@@ -1,18 +1,21 @@
 WITH combined AS (
     SELECT
         s18."mode",
+        s18."share",
         s18.mtco2,
         2018 AS "year"
     FROM {{ ref('stg_commuting_survey_2018') }} AS s18
     UNION ALL
     SELECT
         s21."mode",
+        s21."share",
         s21.mtco2,
         2021 AS "year"
     FROM {{ ref('stg_commuting_survey_2021') }} AS s21
     UNION ALL
     SELECT
         s23."mode",
+        s23."share",
         s23.mtco2,
         2023 AS "year"
     FROM {{ ref('stg_commuting_survey_2023') }} AS s23

--- a/warehouse/models/final/schema.yml
+++ b/warehouse/models/final/schema.yml
@@ -98,6 +98,8 @@ models:
     columns:
       - name: "mode"
         description: "Commute mode"
+      - name: "share"
+        description: "Share of people using the mode in the year"
       - name: mtco2
         description: "Anual equivalent CO2 emission in metric tons"
       - name: year

--- a/warehouse/models/sources.yml
+++ b/warehouse/models/sources.yml
@@ -283,3 +283,15 @@ sources:
             description: "Count of people using shuttle"
           - name: "public transportation"
             description: "Count of people using public transportation"
+      - name: commuting_survey_modes
+        description: "Commuting modes breakdown from commuting survey 2018, 2021 and 2023"
+        meta:
+          dagster:
+            asset_key: ["commuting_survey_modes"]
+        columns:
+          - name: "mode"
+            description: "Commute mode"
+          - name: "count"
+            description: "Daily average of people using the mode"
+          - name: "year"
+            description: "Year of the survey"

--- a/warehouse/models/staging/schema.yml
+++ b/warehouse/models/staging/schema.yml
@@ -99,6 +99,8 @@ models:
     columns:
       - name: "mode"
         description: "Commute mode"
+      - name: "share"
+        description: "Share of people using the mode in the year"
       - name: "miles"
         description: "Daily commute miles by mode"
       - name: mtco2
@@ -110,6 +112,8 @@ models:
     columns:
       - name: "mode"
         description: "Commute mode"
+      - name: "share"
+        description: "Share of people using the mode in the year"
       - name: mtco2
         description: "Anual equivalent CO2 emission in metric tons"
   - name: stg_commuting_survey_2023
@@ -119,6 +123,8 @@ models:
     columns:
       - name: "mode"
         description: "Commute mode"
+      - name: "share"
+        description: "Share of people using the mode in the year"
       - name: "miles"
         description: "Weekly commute miles by mode"
       - name: mtco2

--- a/warehouse/models/staging/stg_commuting_survey_2018.sql
+++ b/warehouse/models/staging/stg_commuting_survey_2018.sql
@@ -9,7 +9,9 @@ WITH binned_count AS (
     SELECT
         drive_alone
         + (1 - {{ transit_ratio }}) * drive_alone_and_public_transport
-        + taxi_and_ride_service AS drive,
+        + taxi_and_ride_service
+        + dropped_off
+        + (1 - {{ transit_ratio }}) * drop_off_and_public_transport AS drive,
         (
             drive_alone_and_public_transport
             + walk_and_public_transport
@@ -17,9 +19,7 @@ WITH binned_count AS (
             + drop_off_and_public_transport
         )
         * {{ transit_ratio }} AS public_transportation,
-        "carpooled(2-6)"
-        + dropped_off
-        + (1 - {{ transit_ratio }}) * drop_off_and_public_transport AS "carpooled(2-6)",
+        "carpooled(2-6)" AS "carpooled(2-6)",
         "vanpooled(7+)",
         commute_time_average_hours
     FROM {{ source('raw', 'commuting_survey_2018') }}

--- a/warehouse/models/staging/stg_commuting_survey_2021.sql
+++ b/warehouse/models/staging/stg_commuting_survey_2021.sql
@@ -36,49 +36,49 @@ duration_with_mode AS (
     SELECT
         'carpooled' AS "mode",
         11 AS mode_id,
-        carpooled / 3 AS duration,
+        carpooled * {{ var('car_share_ratio') }} AS duration,
         {{ var('car_speed') }} AS speed_factor
     FROM total_time
     UNION ALL
     SELECT
         'vanpooled' AS "mode",
         11 AS mode_id,
-        vanpooled / 7 AS duration,
+        vanpooled * {{ var('van_share_ratio') }} AS duration,
         {{ var('car_speed') }} AS speed_factor
     FROM total_time
     UNION ALL
     SELECT
         'shuttle' AS "mode",
         4 AS mode_id,
-        shuttle AS duration,
+        shuttle AS duration, -- shuttle emission factor is per passenger mile
         {{ var('bus_speed') }} AS speed_factor
     FROM total_time
     UNION ALL
     SELECT
         'subway' AS "mode",
         12 AS mode_id,
-        transit / 4 AS duration,
-        {{ var('transit_speed') }} AS speed_factor
+        transit * {{ var('t_ratio') }} AS duration,
+        {{ var('t_speed') }} AS speed_factor
     FROM total_time
     UNION ALL
     SELECT
         'commuter_rail' AS "mode",
         5 AS mode_id,
-        transit / 4 AS duration,
-        {{ var('transit_speed') }} AS speed_factor
+        transit * {{ var('rail_ratio') }} AS duration,
+        {{ var('rail_speed') }} AS speed_factor
     FROM total_time
     UNION ALL
     SELECT
         'intercity' AS "mode",
         7 AS mode_id,
-        transit / 4 AS duration,
-        {{ var('rail_speed') }} AS speed_factor
+        transit * {{ var('intercity_ratio') }} AS duration,
+        {{ var('intercity_speed') }} AS speed_factor
     FROM total_time
     UNION ALL
     SELECT
         'bus' AS "mode",
         4 AS mode_id,
-        transit / 4 AS duration,
+        transit * {{ var('bus_ratio') }} AS duration,
         {{ var('bus_speed') }} AS speed_factor
     FROM total_time
 ),

--- a/warehouse/models/staging/stg_commuting_survey_2023.sql
+++ b/warehouse/models/staging/stg_commuting_survey_2023.sql
@@ -110,7 +110,7 @@ ghg AS (
     SELECT
         "mode",
         mile,
-        mile * "CO2eq_kg" * 2 * {{work_week}} AS ghg -- TO AND FROM, 50 working weeks
+        mile * "CO2eq_kg" * 2 * 5 * {{work_week}} AS ghg -- TO AND FROM, 5 days * 50 working weeks
     FROM attached
 ),
 

--- a/warehouse/models/staging/stg_commuting_survey_2023.sql
+++ b/warehouse/models/staging/stg_commuting_survey_2023.sql
@@ -1,25 +1,35 @@
 -- set static variables using jinja2 syntax
 {% set reply_rate = 0.33 %}
 {% set work_week = 50 %}
+{% set remote_rate = 0.21 %}
 
 WITH distance AS (
     SELECT
         "drove alone" * {{ var('car_speed') }} * commute_time_average_hours AS drove_alone,
-        "carpooled(2-6)" * {{ var('car_speed') }} * commute_time_average_hours AS carpooled,
-        "vanpooled(7+)" * {{ var('car_speed') }} * commute_time_average_hours AS vanpooled,
+        "carpooled(2-6)"
+        * {{ var('car_speed') }}
+        * {{ var('car_share_ratio') }}
+        * commute_time_average_hours AS carpooled,
+        "vanpooled(7+)"
+        * {{ var('car_speed') }}
+        * {{ var('van_share_ratio') }}
+        * commute_time_average_hours AS vanpooled,
         shuttle * {{ var('bus_speed') }} * commute_time_average_hours AS shuttle,
         "public transportation"
-        / 4
-        * {{ var('transit_speed') }}
+        * {{ var('t_ratio') }}
+        * {{ var('t_speed') }}
         * commute_time_average_hours AS subway,
         "public transportation"
-        / 4
-        * {{ var('transit_speed') }}
-        * commute_time_average_hours AS commuter_rail,
-        "public transportation" / 4 * {{ var('bus_speed') }} * commute_time_average_hours AS bus,
-        "public transportation"
-        / 4
+        * {{ var('rail_ratio') }}
         * {{ var('rail_speed') }}
+        * commute_time_average_hours AS commuter_rail,
+        "public transportation"
+        * {{ var('bus_ratio') }}
+        * {{ var('bus_speed') }}
+        * commute_time_average_hours AS bus,
+        "public transportation"
+        * {{ var('intercity_ratio') }}
+        * {{ var('intercity_speed') }}
         * commute_time_average_hours AS intercity
     FROM {{ source('raw', 'commuting_survey_2023') }}
 ),
@@ -106,15 +116,16 @@ attached AS (
 
 ),
 
+-- TO AND FROM, 5 days * 50 working weeks
 ghg AS (
     SELECT
         "mode",
         mile,
-        mile * "CO2eq_kg" * 2 * 5 * {{work_week}} AS ghg -- TO AND FROM, 5 days * 50 working weeks
+        mile * "CO2eq_kg" * 2 * 5 * {{work_week}} AS ghg
     FROM attached
 ),
 
--- Average GHG across various public transport methods
+-- Sum GHG across various public transport methods
 transit_ghg AS (
     SELECT
         'public_transportation' AS "mode",
@@ -130,14 +141,14 @@ emission AS (
     SELECT
         g."mode",
         g.mile,
-        g.ghg / {{ reply_rate }} / 1000 AS mtco2
+        g.ghg * (1 - {{remote_rate}}) / {{ reply_rate }} / 1000 AS mtco2
     FROM ghg AS g
     WHERE g."mode" IN ('drive', 'vanpooled', 'carpooled', 'shuttle')
     UNION ALL
     SELECT
         t."mode",
         t.mile,
-        t.ghg / {{ reply_rate }} / 1000 AS mtco2
+        t.ghg * (1 - {{remote_rate}}) / {{ reply_rate }} / 1000 AS mtco2
     FROM transit_ghg AS t
 )
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] :star2: Feature
- [x] :bug: Bug Fix

## Describe your changes
* Update 2018 survey processing using common parameters (public transportation split and speed factors) as the other two.
* Add mode breakdown to the final `commuting_emission` tables
* New asset to load all commuting mode breakdown

## Documentation
https://mit-sustainability.github.io/portfolio/scope3/commuting/#dashboard
