### PR TITLE
[FY24] Ingest FY24 purchased goods invoices, add auto-materialization for downstream dbt assets

### DIFF
--- a/orchestrator/assets/purchased_goods.py
+++ b/orchestrator/assets/purchased_goods.py
@@ -76,14 +76,11 @@ class InvoiceConfig(Config):
     Example: change this from the asset launchpad to specify the files to load to the data platform.
     """
 
-    files_to_download: List[str] = [
-        "PurchasedGoods_Invoice_FY2019",
-        "PurchasedGoods_Invoice_FY2020",
-    ]
+    files_to_download: List[str] = ["PurchasedGoods_Invoice_FY2024"]
 
 
 @asset(
-    io_manager_key="postgres_replace",  # only use this when loading from scratch, else "postgres_append"
+    io_manager_key="postgres_append",  # only use this when loading from scratch, else "postgres_append"
     compute_kind="python",
     group_name="raw",
     dagster_type=pandera_schema_to_dagster_type(InvoiceSchema),

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -55,6 +55,8 @@ models:
       +meta:
         dagster:
           group: final
+          auto_materialize_policy:
+            type: eager
       +schema: final
       +materialized: view
       +tags:

--- a/warehouse/models/final/purchased_goods_invoice_po_summary.sql
+++ b/warehouse/models/final/purchased_goods_invoice_po_summary.sql
@@ -7,6 +7,6 @@ SELECT
     max(level_2) AS level_2,
     max(level_1) AS level_1,
     string_agg(DISTINCT "description", ', ') AS "description"
-FROM staging.stg_purchased_goods_invoice
+FROM {{ref('stg_purchased_goods_invoice')}}
 GROUP BY po_number, fiscal_year
 ORDER BY fiscal_year

--- a/warehouse/models/staging/schema.yml
+++ b/warehouse/models/staging/schema.yml
@@ -160,6 +160,10 @@ models:
     description: "CPI adjusted and GHG emission enriched invoice data for purchased goods"
     meta:
       owner: yu_cheng@mit.edu
+      dagster:
+        group: staging
+        auto_materialize_policy:
+          type: eager
     columns:
       - name: "sap_invoice_number"
         description: "Unique identifier for SAP-generated invoices."

--- a/warehouse/models/staging/stg_purchased_goods_invoice.sql
+++ b/warehouse/models/staging/stg_purchased_goods_invoice.sql
@@ -1,11 +1,7 @@
 WITH filled AS (
     SELECT
         *,
-        CASE
-            WHEN EXTRACT(MONTH FROM "invoice_date") < 7
-                THEN EXTRACT(YEAR FROM "invoice_date")
-            ELSE EXTRACT(YEAR FROM "invoice_date") + 1
-        END AS fiscal_year,
+        {{ fiscal_year('invoice_date') }}  AS fiscal_year,
         EXTRACT(YEAR FROM "invoice_date") AS invoice_year,
         COALESCE("commodity", "po_line_commodity") AS commodity_filled,
         "total"::FLOAT AS spend
@@ -66,7 +62,7 @@ adjusted AS (
         po_number,
         level_1,
         level_2,
-        level_3, -- same AS commidty
+        level_3,
         total,
         description,
         billing,
@@ -106,4 +102,4 @@ co2kg AS (
 )
 
 
-SELECT * FROM co2kg -- kgCO2e/dollar
+SELECT * FROM co2kg


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] :star2: Feature
- [x] :mag: Test

## Describe your changes
* Ingest new FY24 assets
* Change default `purchased_goods_invoice` asset configuration, now ingesting FY2024, and default to `postgres_append` (possible to configure such in dagster launchpad.)

## Tests
* Test local auto-materialization

## Documentation
* `replace` the `purchased_goods_invoice` asset will drop cascade the downstream dbt assets, use `auto-materialize-policy` as eager to materialize once `purchased_goods_invoice` changed.
* Possible to set `auto-materialize-policy` as dbt meta data in model level, as well as in the schema level. However, the former will overwrite the schema level setting for that model.

## Screenshots
![image](https://github.com/user-attachments/assets/753321ba-739f-413c-a56e-b09a8fdd3f73)


## What gif best describes this PR or how it makes you feel?
<img src="https://media0.giphy.com/media/FAEEL82CUc1JPBas1V/giphy.gif"/>
