### PR TITLE
[Milestone] DLC footprint backend

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -20,6 +20,7 @@ from orchestrator.assets import (
     purchased_goods,
     waste,
     ghg_inventory,
+    ghg_footprint,
 )
 
 from orchestrator.jobs.business_travel_job import business_asset_job
@@ -53,6 +54,7 @@ parking_assets = load_assets_from_modules([parking])
 purchased_goods_assets = load_assets_from_modules([purchased_goods])
 food_assets = load_assets_from_modules([food])
 all_scopes_assets = load_assets_from_modules([ghg_inventory])
+footprint_assets = load_assets_from_modules([ghg_footprint])
 
 defs = Definitions(
     assets=[mitos_dbt_assets]
@@ -63,7 +65,8 @@ defs = Definitions(
     + parking_assets
     + purchased_goods_assets
     + food_assets
-    + all_scopes_assets,
+    + all_scopes_assets
+    + footprint_assets,
     schedules=schedules,
     jobs=[
         business_asset_job,
@@ -83,7 +86,7 @@ defs = Definitions(
         "pg_engine": PostgreConnResources(**PG_CREDENTIALS),
         "em_connect": PostgreConnResources(**EM_CREDENTIALS),
         "dhub": DataHubResource(auth_token=dh_api_key),
-        "dwhrs": MITWHRSResource(**DWRHS_CREDENTIALS),
+        "dwrhs": MITWHRSResource(**DWRHS_CREDENTIALS),
         "s3": S3Resource(region_name="us-east-1"),
         "lambda_pipes_client": PipesLambdaClient(client=boto3.client("lambda")),
     },

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -31,6 +31,7 @@ from orchestrator.jobs.ghg_inventory import ghg_job
 from orchestrator.jobs.parking_job import parking_asset_job
 from orchestrator.jobs.purchased_goods import pgs_job
 from orchestrator.jobs.waste_job import waste_asset_job
+from orchestrator.jobs.dlc_footprint import footprint_job
 from orchestrator.constants import (
     dbt_project_dir,
     DWRHS_CREDENTIALS,
@@ -77,6 +78,7 @@ defs = Definitions(
         pgs_job,
         food_asset_job,
         ghg_job,
+        footprint_job,
     ],
     sensors=[sensor_ghg_manual],
     resources={

--- a/orchestrator/assets/business_travel.py
+++ b/orchestrator/assets/business_travel.py
@@ -202,14 +202,16 @@ def all_scope_summary(dhub: ResourceParam[DataHubResource]):
     compute_kind="python",
     group_name="raw",
 )
-def cost_object_warehouse(dwhrs: MITWHRSResource):
+def cost_object_warehouse(dwrhs: MITWHRSResource):
     """This asset ingest cost object table from MIT warehouse"""
     query = (
-        "SELECT COST_COLLECTOR_ID, DLC_NAME, SCHOOL_AREA, COST_COLLECTOR_EFFECTIVE_DATE " "FROM WAREUSER.COST_COLLECTOR"
+        "SELECT COST_COLLECTOR_ID, DLC_KEY, DLC_NAME, SCHOOL_AREA, COST_COLLECTOR_EFFECTIVE_DATE "
+        "FROM WAREUSER.COST_COLLECTOR"
     )
-    rows = dwhrs.execute_query(query, chunksize=100000)
+    rows = dwrhs.execute_query(query, chunksize=100000)
     columns = [
         "cost_collector_id",
+        "dlc_key",
         "dlc_name",
         "school_area",
         "cost_collector_effective_date",

--- a/orchestrator/assets/ghg_footprint.py
+++ b/orchestrator/assets/ghg_footprint.py
@@ -1,0 +1,146 @@
+from datetime import datetime
+from dagster import asset, Output, get_dagster_logger, MetadataValue, ResourceParam
+from dagster_aws.s3 import S3Resource
+from dagster_pandera import pandera_schema_to_dagster_type
+import pandas as pd
+import pandera as pa
+from pandera.typing import Series, DateTime
+
+from orchestrator.assets.utils import (
+    empty_dataframe_from_model,
+    add_dhub_sync,
+    normalize_column_name,
+)
+from orchestrator.resources.datahub import DataHubResource
+from orchestrator.resources.postgres_io_manager import PostgreConnResources
+from orchestrator.resources.mit_warehouse import MITWHRSResource
+
+
+logger = get_dagster_logger()
+
+
+@asset(io_manager_key="postgres_replace", compute_kind="python", group_name="raw")
+def dlc_person_share(dwrhs: MITWHRSResource) -> Output[pd.DataFrame]:
+    """Load DLC personnel count from data warehouse"""
+    logger.info("Connect to MIT data warehouse to ingest Personnel count for each DLC")
+    query = """
+            WITH hc AS (
+                SELECT DEPARTMENT_NUMBER, COUNT(*) AS headcount
+                FROM WAREUSER.EMPLOYEE_DIRECTORY
+                WHERE DEPARTMENT_NAME NOT LIKE 'Lincoln%'
+                AND DEPARTMENT_NAME NOT LIKE 'Haystack%'
+                GROUP BY DEPARTMENT_NUMBER
+            ),
+
+            org_dlc AS (
+                SELECT HR_DEPARTMENT_CODE_OLD, DLC_KEY
+                FROM WAREUSER.HR_ORG_UNIT_NEW
+                GROUP BY HR_DEPARTMENT_CODE_OLD, DLC_KEY
+            ),
+
+            dlc_hc AS (
+                SELECT
+                    fo.DLC_KEY,
+                    SUM(hc.headcount) AS total_employee
+                FROM hc
+                LEFT JOIN org_dlc fo
+                ON hc.DEPARTMENT_NUMBER = fo.HR_DEPARTMENT_CODE_OLD
+                GROUP BY DLC_KEY
+            )
+
+            SELECT
+                DLC_KEY,
+                TOTAL_EMPLOYEE,
+                TOTAL_EMPLOYEE / (SUM(TOTAL_EMPLOYEE) OVER ()) AS percentage
+            FROM dlc_hc
+            ORDER BY TOTAL_EMPLOYEE DESC
+        """
+    rows = dwrhs.execute_query(query, chunksize=100000)
+    columns = ["dlc_key", "total_employee", "percentage"]
+    df = pd.DataFrame(rows, columns=columns)
+    logger.info("Query executed successfully. Extract Personnel Count for DLCs")
+    metadata = {
+        "number_of_DLCs": len(df),
+    }
+    # Add an id column, and a timestamp column to the dataframe
+    df.insert(0, "id", df.index + 1)
+    df["last_update"] = datetime.now()
+    # Convert FY columns to integer
+    return Output(value=df, metadata=metadata)
+
+
+@asset(io_manager_key="postgres_replace", compute_kind="python", group_name="raw")
+def dlc_floor_share(dwrhs: MITWHRSResource) -> Output[pd.DataFrame]:
+    """Load Building DLC share from data warehouse"""
+    logger.info("Connect to MIT data warehouse to ingest floor area share for each DLC and building")
+    query = """
+            WITH DistinctDLC AS (
+                    SELECT DISTINCT FCLT_ORGANIZATION_KEY, DLC_KEY
+                    FROM WAREUSER.FCLT_ORG_DLC_KEY
+                ),
+
+                BuildingTotal AS (
+                    SELECT
+                        FCLT_BUILDING_KEY,
+                        SUM(AREA) AS total_floor_area
+                    FROM WAREUSER.FCLT_ROOMS r
+                    LEFT JOIN DistinctDLC d
+                        ON r.FCLT_ORGANIZATION_KEY = d.FCLT_ORGANIZATION_KEY
+                    GROUP BY FCLT_BUILDING_KEY
+                ),
+
+                bd_breakdown AS (
+                    SELECT
+                        r.FCLT_BUILDING_KEY,
+                        d.DLC_KEY,
+                        SUM(r.AREA) AS total_area
+                    FROM WAREUSER.FCLT_ROOMS r
+                    LEFT JOIN DistinctDLC d
+                        ON r.FCLT_ORGANIZATION_KEY = d.FCLT_ORGANIZATION_KEY
+                    WHERE d.DLC_KEY IS NOT NULL
+                    GROUP BY r.FCLT_BUILDING_KEY, d.DLC_KEY
+                ),
+
+                bd_share AS (
+                    SELECT
+                        bd.*,
+                        bt.total_floor_area,
+                        bd.total_area / bt.total_floor_area AS dlc_share
+                    FROM bd_breakdown bd
+                    LEFT JOIN BuildingTotal bt
+                        ON bt.FCLT_BUILDING_KEY = bd.FCLT_BUILDING_KEY
+                )
+
+                SELECT FCLT_BUILDING_KEY, DLC_KEY, TOTAL_AREA, DLC_SHARE FROM bd_share
+            """
+
+    rows = dwrhs.execute_query(query, chunksize=100000)
+    columns = [
+        "fclt_building_key",
+        "dlc_key",
+        "total_area",
+        "dlc_share",
+    ]
+    df = pd.DataFrame(rows, columns=columns)
+    logger.info("Query executed successfully. Extract Assigned Space Share for DLCs")
+    number_dlc = df["dlc_key"].nunique()
+    metadata = {
+        "number_of_DLCs": number_dlc,
+    }
+    # Add an id column, and a timestamp column to the dataframe
+    df["last_update"] = datetime.now()
+    # Convert FY columns to integer
+    return Output(value=df, metadata=metadata)
+
+
+# Sync processed table back to datahub
+# dhub_ghg_inventory = add_dhub_sync(
+#     asset_name="dhub_ghg_inventory",
+#     table_key=["staging", "stg_ghg_inventory"],
+#     config={
+#         "filename": "ghg_inventory.csv",
+#         "project_name": "GHG_Inventory",
+#         "description": "Aggregated GHG inventory emissions by categories",
+#         "title": "Aggregated GHG Inventory",
+#     },
+# )

--- a/orchestrator/assets/ghg_footprint.py
+++ b/orchestrator/assets/ghg_footprint.py
@@ -183,5 +183,6 @@ dhub_dlc_footprint = add_dhub_sync(
         "project_name": "GHG_Inventory",
         "description": "GHG footprint broken down by DLCs and fiscal year",
         "title": "DLC-based GHG footprint",
+        "ext": "parquet",
     },
 )

--- a/orchestrator/assets/ghg_footprint.py
+++ b/orchestrator/assets/ghg_footprint.py
@@ -1,18 +1,13 @@
 from datetime import datetime
-from dagster import asset, Output, get_dagster_logger, MetadataValue, ResourceParam
-from dagster_aws.s3 import S3Resource
-from dagster_pandera import pandera_schema_to_dagster_type
+from dagster import asset, Output, get_dagster_logger, MetadataValue
 import pandas as pd
-import pandera as pa
 from pandera.typing import Series, DateTime
 
 
 from orchestrator.assets.utils import (
-    empty_dataframe_from_model,
     add_dhub_sync,
     normalize_column_name,
 )
-from orchestrator.resources.datahub import DataHubResource
 from orchestrator.resources.postgres_io_manager import PostgreConnResources
 from orchestrator.resources.mit_warehouse import MITWHRSResource
 
@@ -180,13 +175,13 @@ def energy_distribution(em_connect: PostgreConnResources) -> Output[pd.DataFrame
 
 
 # Sync processed table back to datahub
-# dhub_ghg_inventory = add_dhub_sync(
-#     asset_name="dhub_ghg_inventory",
-#     table_key=["staging", "stg_ghg_inventory"],
-#     config={
-#         "filename": "ghg_inventory.csv",
-#         "project_name": "GHG_Inventory",
-#         "description": "Aggregated GHG inventory emissions by categories",
-#         "title": "Aggregated GHG Inventory",
-#     },
-# )
+dhub_dlc_footprint = add_dhub_sync(
+    asset_name="dhub_dlc_footprint",
+    table_key=["final", "final_footprint_records"],
+    config={
+        "filename": "dlc_footprint.csv",
+        "project_name": "GHG_Inventory",
+        "description": "GHG footprint broken down by DLCs and fiscal year",
+        "title": "DLC-based GHG footprint",
+    },
+)

--- a/orchestrator/assets/ghg_inventory.py
+++ b/orchestrator/assets/ghg_inventory.py
@@ -40,6 +40,9 @@ class EnergySchema(pa.SchemaModel):
     last_update: Series[DateTime] = pa.Field(description="Date of last update")
 
 
+EnergySchemaType = pandera_schema_to_dagster_type(EnergySchema)
+
+
 @asset(
     io_manager_key="postgres_replace",
     compute_kind="python",
@@ -67,7 +70,7 @@ def ghg_manual_entries(s3: S3Resource) -> Output[pd.DataFrame]:
     io_manager_key="postgres_replace",
     compute_kind="python",
     group_name="raw",
-    dagster_type=pandera_schema_to_dagster_type(EnergySchema),
+    dagster_type=EnergySchemaType,
 )
 def purchased_energy(em_connect: PostgreConnResources) -> Output[pd.DataFrame]:
     """Load purchased energy numbers from energy-cdr in energize-mit database"""

--- a/orchestrator/assets/parking.py
+++ b/orchestrator/assets/parking.py
@@ -69,7 +69,7 @@ def historical_parking_daily(dhub: ResourceParam[DataHubResource]):
     group_name="raw",
     dagster_type=pandera_schema_to_dagster_type(ParkingNewbatchData),
 )
-def newbatch_parking_daily(dwhrs: MITWHRSResource):
+def newbatch_parking_daily(dwrhs: MITWHRSResource):
     """This asset ingest the new batch of parking activity data from MIT Warehouse"""
     query = """
             SELECT ENTRY_DATE AS "date",
@@ -82,7 +82,7 @@ def newbatch_parking_daily(dwhrs: MITWHRSResource):
                 AND TO_CHAR(ENTRY_DATE, 'DY', 'NLS_DATE_LANGUAGE = AMERICAN') NOT IN ('SAT', 'SUN')
             GROUP BY ENTRY_DATE, PARKING_LOT_ID
             """
-    rows = dwhrs.execute_query(query, chunksize=100000)
+    rows = dwrhs.execute_query(query, chunksize=100000)
     columns = [
         "date",
         "parking_lot",
@@ -100,7 +100,7 @@ def newbatch_parking_daily(dwhrs: MITWHRSResource):
     compute_kind="python",
     group_name="raw",
 )
-def mit_holidays(dwhrs: MITWHRSResource):
+def mit_holidays(dwrhs: MITWHRSResource):
     """This asset ingest the MIT holidays data from MIT Warehouse"""
     query = """
             SELECT HOLIDAY_CLOSING_DATE AS "date",
@@ -112,7 +112,7 @@ def mit_holidays(dwhrs: MITWHRSResource):
                 AND HOLIDAY_CLOSING_DATE < SYSDATE
             ORDER BY HOLIDAY_CLOSING_DATE
             """
-    rows = dwhrs.execute_query(query, chunksize=100000)
+    rows = dwrhs.execute_query(query, chunksize=100000)
     columns = [
         "date",
         "holiday",

--- a/orchestrator/jobs/dlc_footprint.py
+++ b/orchestrator/jobs/dlc_footprint.py
@@ -1,0 +1,11 @@
+from dagster import define_asset_job
+from dagster_dbt import build_dbt_asset_selection
+from orchestrator.assets.postgres import mitos_dbt_assets
+
+dbt_selection = build_dbt_asset_selection([mitos_dbt_assets], dbt_select="final_footprint_records")
+footprint_assets = dbt_selection.downstream() | dbt_selection.upstream(depth=1)
+
+footprint_job = define_asset_job(
+    name="dlc_footprint_job",
+    selection=footprint_assets,
+)

--- a/orchestrator/resources/datahub.py
+++ b/orchestrator/resources/datahub.py
@@ -12,7 +12,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_exception_t
 from requests.exceptions import SSLError
 
 logger = get_dagster_logger()
-default_timeout = 10
+default_timeout = 30
 
 
 @retry(

--- a/warehouse/.sqlfluff
+++ b/warehouse/.sqlfluff
@@ -1,7 +1,7 @@
 [sqlfluff]
 templater = jinja
 sql_file_exts = .sql
-exclude_rules = L034,L029,L057,L013,L014
+exclude_rules = L034,L029,L057,L013
 dialect = postgres
 max_line_length = 100
 

--- a/warehouse/.sqlfluff
+++ b/warehouse/.sqlfluff
@@ -1,7 +1,7 @@
 [sqlfluff]
 templater = jinja
 sql_file_exts = .sql
-exclude_rules = L034,L029,L057,L013
+exclude_rules = L034,L029,L057,L013,L014
 dialect = postgres
 max_line_length = 100
 

--- a/warehouse/.sqlfluff
+++ b/warehouse/.sqlfluff
@@ -1,7 +1,7 @@
 [sqlfluff]
 templater = jinja
 sql_file_exts = .sql
-exclude_rules = L034,L029,L057
+exclude_rules = L034,L029,L057,L013,L014
 dialect = postgres
 max_line_length = 100
 
@@ -9,6 +9,9 @@ max_line_length = 100
 # Line length
 ignore_comment_lines = True
 ignore_comment_clauses = True
+
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = consistent
 
 [sqlfluff:templater:jinja]
 apply_dbt_builtins = True

--- a/warehouse/models/final/final_footprint_records.sql
+++ b/warehouse/models/final/final_footprint_records.sql
@@ -45,6 +45,13 @@ pgs AS (
     ORDER BY fiscal_year
 ),
 
+unique_dlc AS (
+    SELECT DISTINCT
+        dlc_name,
+        school_area
+    FROM {{ ref('stg_cost_object_rollup') }}
+),
+
 pgs_dlc AS (
     SELECT
         pgs.fiscal_year,
@@ -53,7 +60,7 @@ pgs_dlc AS (
         pgs.dlc_name,
         c.school_area
     FROM pgs
-    LEFT JOIN {{ ref('stg_cost_object_rollup') }} AS c
+    LEFT JOIN unique_dlc AS c
         ON pgs.dlc_name = c.dlc_name
 ),
 
@@ -71,3 +78,4 @@ SELECT
     row_number() OVER (ORDER BY fiscal_year, category) AS id,
     *
 FROM recording
+WHERE fiscal_year >= 2014

--- a/warehouse/models/final/final_footprint_records.sql
+++ b/warehouse/models/final/final_footprint_records.sql
@@ -1,0 +1,73 @@
+WITH capita AS (
+    SELECT
+        fiscal_year,
+        CASE
+            WHEN category = '3.2 Construction' THEN '3.2 Capital Goods'
+            ELSE category
+        END AS category,
+        emission,
+        dlc_name,
+        school_area
+    FROM {{ ref('stg_dlc_footprint_capita') }}
+),
+
+energy AS (
+    SELECT
+        fiscal_year,
+        '1 & 2 Energy' AS category,
+        emission,
+        dlc_name,
+        school_area
+    FROM {{ ref('stg_dlc_energy_summary') }}
+),
+
+travel AS (
+    SELECT
+        fiscal_year,
+        '3.6 Business Travel' AS category,
+        sum(mtco2) AS emission,
+        dlc_name,
+        max(school_area) AS school_area
+    FROM {{ ref('stg_travel_spending') }}
+    WHERE dlc_name IS NOT NULL
+    GROUP BY fiscal_year, dlc_name
+),
+
+pgs AS (
+    SELECT
+        fiscal_year,
+        '3.1 Purchased Goods and Services' AS category,
+        sum(mtco2) AS emission,
+        dlc_name
+    FROM {{ ref('stg_purchased_goods_invoice') }}
+    WHERE dlc_name IS NOT NULL
+    GROUP BY fiscal_year, dlc_name
+    ORDER BY fiscal_year
+),
+
+pgs_dlc AS (
+    SELECT
+        pgs.fiscal_year,
+        pgs.category,
+        pgs.emission,
+        pgs.dlc_name,
+        c.school_area
+    FROM pgs
+    LEFT JOIN {{ ref('stg_cost_object_rollup') }} AS c
+        ON pgs.dlc_name = c.dlc_name
+),
+
+recording AS (
+    SELECT e.* FROM energy AS e
+    UNION ALL
+    SELECT c.* FROM capita AS c
+    UNION ALL
+    SELECT p.* FROM pgs_dlc AS p
+    UNION ALL
+    SELECT t.* FROM travel AS t
+)
+
+SELECT
+    row_number() OVER (ORDER BY fiscal_year, category) AS id,
+    *
+FROM recording

--- a/warehouse/models/final/schema.yml
+++ b/warehouse/models/final/schema.yml
@@ -217,6 +217,11 @@ models:
     description: "Combined GHG footprint recordings of MIT DLCs"
     meta:
       owner: yu_cheng@mit.edu
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - dlc_name
+            - fiscal_year
     columns:
       - name: id
         description: "Unique identifier for DLC footprint record"

--- a/warehouse/models/final/schema.yml
+++ b/warehouse/models/final/schema.yml
@@ -213,3 +213,20 @@ models:
         description: "GHG scope 1, 2, or 3"
       - name: last_update
         description: "Timestamp of the entry being added"
+  - name: final_footprint_records
+    description: "Combined GHG footprint recordings of MIT DLCs"
+    meta:
+      owner: yu_cheng@mit.edu
+    columns:
+      - name: id
+        description: "Unique identifier for DLC footprint record"
+      - name: fiscal_year
+        description: "MIT fiscal year (July to June)"
+      - name: category
+        description: "GHG category"
+      - name: emission
+        description: "Total DLC GHG emission (MtCO2)"
+      - name: dlc_name
+        description: "MIT Department, Lab, and Center name"
+      - name: school_area
+        description: "School Area"

--- a/warehouse/models/sources.yml
+++ b/warehouse/models/sources.yml
@@ -44,6 +44,8 @@ sources:
         columns:
           - name: cost_object
             description: "Cost Object ID"
+          - name: dlc_key
+            description: "MIT Department, Lab, and Center key in Warehouse"
           - name: dlc_name
             description: "MIT Department, Lab, and Center name"
           - name: school_area
@@ -460,6 +462,8 @@ sources:
           dagster:
             asset_key: ["purchased_energy"]
         columns:
+          - name: building_number
+            description: "MIT building number"
           - name: gl_account_key
             description: "GL Account Key"
           - name: start_date
@@ -497,6 +501,53 @@ sources:
             description: "Duplicated Level 3 Category for purchased goods and services"
           - name: id
             description: "unique identifier"
+      - name: ghg_categories
+        description: Greenhouse Gas categories for MIT following GHG protocol
+        meta:
+          owner: yu_cheng@mit.edu
+          dagster:
+            asset_key: ["ghg_categories"]
+        columns:
+          - name: id
+            description: "unique identifier"
+          - name: name
+            description: "GHG category name"
+          - name: description
+            description: "GHG category description"
+      - name: dlc_person_share
+        description: DLC share of campus total based on number of employees
+        meta:
+          owner: yu_cheng@mit.edu
+          dagster:
+            asset_key: ["dlc_person_share"]
+        columns:
+          - name: id
+            description: "unique identifier"
+          - name: dlc_key
+            description: "MIT Department, Lab, and Center key in Warehouse"
+          - name: total_employee
+            description: "Total number of employees of the DLC"
+          - name: percentage
+            description: "percentage of DLC employee of total MIT employees"
+          - name: last_update
+            description: "Last update timestamp"
+      - name: dlc_area_share
+        description: DLC share of building energy used based on assigned areas
+        meta:
+          owner: yu_cheng@mit.edu
+          dagster:
+            asset_key: ["dlc_area_share"]
+        columns:
+          - name: fclt_building_key
+            description: "MIT building key"
+          - name: dlc_key
+            description: "MIT Department, Lab, and Center key in Warehouse"
+          - name: total_area
+            description: "Total assigned area of the DLC in the building"
+          - name: dlc_share
+            description: "share of assigned area from the building total for the DLC"
+          - name: last_update
+            description: "Last update timestamp"
   - name: staging
     description: Python generated file in the MITOS warehouse with initial data processing
     schema: staging

--- a/warehouse/models/sources.yml
+++ b/warehouse/models/sources.yml
@@ -548,6 +548,41 @@ sources:
             description: "share of assigned area from the building total for the DLC"
           - name: last_update
             description: "Last update timestamp"
+      - name: energy_distribution
+        description: Energy distribution data from energy_cdr table in energize-mit
+        meta:
+          owner: yu_cheng@mit.edu
+          dagster:
+            asset_key: ["energy_distribution"]
+        columns:
+          - name: building_number
+            description: "MIT building number"
+          - name: gl_account_key
+            description: "GL Account Key"
+          - name: start_date
+            description: "Start Date"
+          - name: start_date_use
+            description: "Start Date for Use"
+          - name: billing_fy
+            description: "Billing Fiscal Year"
+          - name: use_fy
+            description: "Use Fiscal Year"
+          - name: ghg
+            description: "Greenhouse Gas Emission"
+          - name: unit_of_measure
+            description: "Unit of Measure"
+          - name: number_of_units
+            description: "Number of Units"
+          - name: building_group_level1
+            description: "Building Group Level 1"
+          - name: level1_category
+            description: "Level 1 Category"
+          - name: level2_category
+            description: "Level 2 Category"
+          - name: level3_category
+            description: "Level 3 Category"
+          - name: last_update
+            description: "Last Update timestamp"
   - name: staging
     description: Python generated file in the MITOS warehouse with initial data processing
     schema: staging

--- a/warehouse/models/staging/schema.yml
+++ b/warehouse/models/staging/schema.yml
@@ -321,6 +321,72 @@ models:
         description: "GHG scope 1, 2, or 3"
       - name: last_update
         description: "Timestamp of the entry being modified"
+  - name: stg_building_energy
+    description: "Scope 1+2 GHG breakdown by building and fiscal_year"
+    meta:
+      owner: yu_cheng@mit.edu
+      group: staging
+      automation_condition:
+        type: eager
+    columns:
+      - name: building_number
+        description: "MIT Building number"
+      - name: fiscal_year
+        description: "MIT fiscal year (July to June)"
+      - name: emission
+        description: "GHG emission in metric tons"
+      - name: last_update
+        description: "Timestamp of the entry being modified"
+  - name: stg_building_dlc_share
+    description: "Adjust area-based share to building groups"
+    meta:
+      owner: yu_cheng@mit.edu
+      group: staging
+    columns:
+      - name: building_number
+        description: "MIT Building number"
+      - name: dlc_key
+        description: "MIT Department, Lab, and Center key in Warehouse"
+      - name: dlc_assigned_area
+        description: "DLC assigned area in the building"
+      - name: building_total_area
+        description: "Total assignable area of the building"
+      - name: dlc_share
+        description: "share of assigned area from the building total for the DLC"
+  - name: stg_dlc_energy_summary
+    description: "Add up energy consumption by DL used assigned area share in each building"
+    meta:
+      owner: yu_cheng@mit.edu
+      group: staging
+    columns:
+      - name: fiscal_year
+        description: "MIT fiscal year (July to June)"
+      - name: dlc_key
+        description: "MIT Department, Lab, and Center key in Warehouse"
+      - name: emission
+        description: "Total DLC GHG emission (MtCO2)"
+      - name: dlc_name
+        description: "MIT Department, Lab, and Center name"
+      - name: school_area
+        description: "School Area"
+  - name: stg_dlc_footprint_capita
+    description: "Add up energy consumption by DL used assigned area share in each building"
+    meta:
+      owner: yu_cheng@mit.edu
+      group: staging
+    columns:
+      - name: fiscal_year
+        description: "MIT fiscal year (July to June)"
+      - name: category
+        description: "GHG category"
+      - name: dlc_key
+        description: "MIT Department, Lab, and Center key in Warehouse"
+      - name: emission
+        description: "Total DLC GHG emission (MtCO2)"
+      - name: dlc_name
+        description: "MIT Department, Lab, and Center name"
+      - name: school_area
+        description: "School Area"
 unit_tests:
   - name: test_waste_split_adjustment
     description: >

--- a/warehouse/models/staging/schema.yml
+++ b/warehouse/models/staging/schema.yml
@@ -379,6 +379,9 @@ models:
         description: "MIT fiscal year (July to June)"
       - name: category
         description: "GHG category"
+        data_tests:
+          - accepted_values:
+              values: ['3.5 Waste', '3.2 Construction']
       - name: dlc_key
         description: "MIT Department, Lab, and Center key in Warehouse"
       - name: emission

--- a/warehouse/models/staging/stg_building_dlc_share.sql
+++ b/warehouse/models/staging/stg_building_dlc_share.sql
@@ -105,47 +105,47 @@ WITH building_groups AS (
     UNION ALL
     SELECT
         'W85',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85A',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85B',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85C',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85D',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85E',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85F',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85G',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85H',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85J',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         'W85K',
-        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+        'W85_W85ABC_W85DE_W85FG_W85HJK'
     UNION ALL
     SELECT
         '32P',
@@ -174,6 +174,70 @@ WITH building_groups AS (
     SELECT
         'W18P',
         'Parking Areas'
+    UNION ALL
+    SELECT
+        'OC19A',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19B',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19C',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19D',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19E',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19F',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19G',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19H',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19J',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19K',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19L',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19M',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19N',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'OC19Q',
+        'OC19_ABCDEFGHJKLMNQ'
+    UNION ALL
+    SELECT
+        'W2',
+        'W2_W4'
+    UNION ALL
+    SELECT
+        'W4',
+        'W2_W4'
 ),
 
 bd_grouped AS (
@@ -181,7 +245,7 @@ bd_grouped AS (
         COALESCE(bg.grouped_building, bd.fclt_building_key) AS fclt_building_key,
         bd.dlc_key,
         SUM(bd.total_area) AS total_area
-    FROM raw.dlc_floor_share AS bd
+    FROM {{ source('raw','dlc_area_share') }} AS bd
     LEFT JOIN building_groups AS bg ON bd.fclt_building_key = bg.fclt_building_key
     GROUP BY COALESCE(bg.grouped_building, bd.fclt_building_key), bd.dlc_key
 ),

--- a/warehouse/models/staging/stg_building_dlc_share.sql
+++ b/warehouse/models/staging/stg_building_dlc_share.sql
@@ -1,0 +1,216 @@
+WITH building_groups AS (
+    SELECT
+        '64B' AS fclt_building_key,
+        '62_64' AS grouped_building
+    UNION ALL
+    SELECT
+        '64G',
+        '62_64'
+    UNION ALL
+    SELECT
+        '62H',
+        '62_64'
+    UNION ALL
+    SELECT
+        '62M',
+        '62_64'
+    UNION ALL
+    SELECT
+        '62W',
+        '62_64'
+    UNION ALL
+    SELECT
+        '64W',
+        '62_64'
+    UNION ALL
+    SELECT
+        '6B',
+        '6_6B'
+    UNION ALL
+    SELECT
+        '6',
+        '6_6B'
+    UNION ALL
+    SELECT
+        '7',
+        '7_7A'
+    UNION ALL
+    SELECT
+        '7A',
+        '7_7A'
+    UNION ALL
+    SELECT
+        'NW12',
+        'NW12_NW12A'
+    UNION ALL
+    SELECT
+        'NW12A',
+        'NW12_NW12A'
+    UNION ALL
+    SELECT
+        'W53',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53A',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53B',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53C',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53D',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53E',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53F',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        'W53G',
+        'W53_W53A_W53B_W53C_W53D'
+    UNION ALL
+    SELECT
+        '42',
+        '42_43_N16_E40'
+    UNION ALL
+    SELECT
+        '43',
+        '42_43_N16_E40'
+    UNION ALL
+    SELECT
+        'N16',
+        '42_43_N16_E40'
+    UNION ALL
+    SELECT
+        'E40',
+        '42_43_N16_E40'
+    UNION ALL
+    SELECT
+        '42T',
+        '42_43_N16_E40'
+    UNION ALL
+    SELECT
+        '42C',
+        '42_43_N16_E40'
+    UNION ALL
+    SELECT
+        'W85',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85A',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85B',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85C',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85D',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85E',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85F',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85G',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85H',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85J',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        'W85K',
+        'W85_W85A_W85B_W85C_W85D_W85E_W85F_W85G_W85H_W85J_W85K'
+    UNION ALL
+    SELECT
+        '32P',
+        'Parking Areas'
+    UNION ALL
+    SELECT
+        'W18P',
+        'Parking Areas'
+    UNION ALL
+    SELECT
+        'E37P',
+        'Parking Areas'
+    UNION ALL
+    SELECT
+        'E53P',
+        'Parking Areas'
+    UNION ALL
+    SELECT
+        'E62P',
+        'Parking Areas'
+    UNION ALL
+    SELECT
+        'NW86P',
+        'Parking Areas'
+    UNION ALL
+    SELECT
+        'W18P',
+        'Parking Areas'
+),
+
+bd_grouped AS (
+    SELECT
+        COALESCE(bg.grouped_building, bd.fclt_building_key) AS fclt_building_key,
+        bd.dlc_key,
+        SUM(bd.total_area) AS total_area
+    FROM raw.dlc_floor_share AS bd
+    LEFT JOIN building_groups AS bg ON bd.fclt_building_key = bg.fclt_building_key
+    GROUP BY COALESCE(bg.grouped_building, bd.fclt_building_key), bd.dlc_key
+),
+
+total_area_per_dlc AS (
+    SELECT
+        fclt_building_key,
+        SUM(total_area) AS total_floor_area
+    FROM bd_grouped
+    GROUP BY fclt_building_key
+),
+
+adjusted_share AS (
+    SELECT
+        bg.fclt_building_key,
+        bg.dlc_key,
+        bg.total_area AS dlc_assigned_area,
+        ta.total_floor_area AS building_total_area,
+        bg.total_area / NULLIF(ta.total_floor_area, 0) AS dlc_share
+    FROM bd_grouped AS bg
+    LEFT JOIN total_area_per_dlc AS ta
+        ON bg.fclt_building_key = ta.fclt_building_key
+)
+
+SELECT
+    fclt_building_key AS building_number,
+    dlc_key,
+    dlc_assigned_area,
+    building_total_area,
+    dlc_share
+FROM adjusted_share
+ORDER BY fclt_building_key

--- a/warehouse/models/staging/stg_building_energy.sql
+++ b/warehouse/models/staging/stg_building_energy.sql
@@ -1,11 +1,11 @@
 WITH cdr AS (
-    -- Extract purchased energy emissions by buildings
+    -- Extract Energy related emissions by buildings
     SELECT
         ghg,
         billing_fy AS fiscal_year,
         building_number,
         last_update::timestamp AS last_update
-    FROM {{ source("raw", "purchased_energy") }}
+    FROM {{ source("raw", "energy_distribution") }}
 )
 
 SELECT

--- a/warehouse/models/staging/stg_building_energy.sql
+++ b/warehouse/models/staging/stg_building_energy.sql
@@ -1,0 +1,17 @@
+WITH cdr AS (
+    -- Extract purchased energy emissions by buildings
+    SELECT
+        ghg,
+        billing_fy AS fiscal_year,
+        building_number,
+        last_update::timestamp AS last_update
+    FROM {{ source("raw", "purchased_energy") }}
+)
+
+SELECT
+    building_number,
+    fiscal_year,
+    sum(ghg) AS emission,
+    max(last_update)::timestamp AS last_update
+FROM cdr
+GROUP BY fiscal_year, building_number

--- a/warehouse/models/staging/stg_dlc_energy_summary.sql
+++ b/warehouse/models/staging/stg_dlc_energy_summary.sql
@@ -53,4 +53,5 @@ SELECT
 FROM DLC_Emission_Summary AS s
 LEFT JOIN DLC_Mapping AS d
     ON s.dlc_key = d.dlc_key
+WHERE d.dlc_name IS NOT NULL
 ORDER BY s.fiscal_year, s.dlc_key

--- a/warehouse/models/staging/stg_dlc_energy_summary.sql
+++ b/warehouse/models/staging/stg_dlc_energy_summary.sql
@@ -33,7 +33,7 @@ DLC_Emission_Summary AS (
     GROUP BY fiscal_year, dlc_key
 ),
 
-Dlc_Mapping AS (
+DLC_Mapping AS (
     SELECT
         dlc_key,
         dlc_name,
@@ -51,6 +51,6 @@ SELECT
     d.dlc_name,
     d.school_area
 FROM DLC_Emission_Summary AS s
-LEFT JOIN Dlc_Mapping AS d
+LEFT JOIN DLC_Mapping AS d
     ON s.dlc_key = d.dlc_key
 ORDER BY s.fiscal_year, s.dlc_key

--- a/warehouse/models/staging/stg_dlc_energy_summary.sql
+++ b/warehouse/models/staging/stg_dlc_energy_summary.sql
@@ -1,0 +1,56 @@
+WITH DLCShare AS (
+    SELECT
+        building_number,
+        dlc_key,
+        dlc_share
+    FROM {{ ref('stg_building_dlc_share') }}
+),
+
+EmissionData AS (
+    SELECT
+        building_number,
+        fiscal_year,
+        emission
+    FROM {{ ref('stg_building_energy') }}
+),
+
+DLC_Emission AS (
+    SELECT
+        e.fiscal_year,
+        d.dlc_key,
+        (e.emission * d.dlc_share) AS dlc_emission
+    FROM EmissionData AS e
+    INNER JOIN DLCShare AS d
+        ON e.building_number = d.building_number
+),
+
+DLC_Emission_Summary AS (
+    SELECT
+        fiscal_year,
+        dlc_key,
+        SUM(dlc_emission) AS total_dlc_emission
+    FROM DLC_Emission
+    GROUP BY fiscal_year, dlc_key
+),
+
+Dlc_Mapping AS (
+    SELECT
+        dlc_key,
+        dlc_name,
+        MAX(School_Area) AS School_Area
+    FROM {{ source('raw', 'cost_object_warehouse') }}
+    WHERE dlc_key IS NOT NULL
+    GROUP BY dlc_key, dlc_name
+)
+
+
+SELECT
+    s.fiscal_year,
+    s.dlc_key,
+    s.total_dlc_emission AS emission,
+    d.dlc_name,
+    d.school_area
+FROM DLC_Emission_Summary AS s
+LEFT JOIN Dlc_Mapping AS d
+    ON s.dlc_key = d.dlc_key
+ORDER BY s.fiscal_year, s.dlc_key

--- a/warehouse/models/staging/stg_dlc_footprint_capita.sql
+++ b/warehouse/models/staging/stg_dlc_footprint_capita.sql
@@ -1,0 +1,46 @@
+WITH FilteredEmissions AS (
+    SELECT
+        category,
+        fiscal_year,
+        SUM(emission) AS total_emission
+    FROM {{ ref('stg_ghg_inventory') }}
+    WHERE category IN ('3.5 Waste', '3.2 Construction')
+    GROUP BY category, fiscal_year
+),
+
+DLC_Emissions AS (
+    SELECT
+        e.fiscal_year,
+        e.category,
+        e.total_emission,
+        d.dlc_key,
+        d.percentage,
+        (e.total_emission * d.percentage) AS dlc_emission
+    FROM FilteredEmissions AS e
+    INNER JOIN {{ source('raw', 'dlc_person_share') }} AS d
+        ON 1 = 1  -- Cartesian join to distribute emissions proportionally
+),
+
+dlc_mapping AS (
+    SELECT
+        dlc_key,
+        dlc_name,
+        MAX(school_area) AS school_area
+    FROM {{ source('raw', 'cost_object_warehouse') }}
+    WHERE dlc_key IS NOT NULL
+    GROUP BY dlc_key, dlc_name
+)
+
+
+SELECT
+    e.fiscal_year,
+    e.category,
+    e.dlc_key,
+    e.dlc_emission AS emission,
+    d.dlc_name,
+    d.school_area
+FROM DLC_Emissions AS e
+LEFT JOIN dlc_mapping AS d
+    ON e.dlc_key = d.dlc_key
+WHERE d.dlc_name IS NOT NULL
+ORDER BY e.fiscal_year, e.category


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] :star2: Feature

## Describe your changes
- Added pipeline to allocate campus total GHG (Scope 1, 2 and 3) to DLC level
- New assets:
    - DLC_area_share
    - DLC_person_share
    - energy_distribution (same as energy_cdr from energize_mit)
    - dhub_dlc_footprint (sync the footprint records to datahub)
    - stg_building_dlc_share (aggregate building into groups aligned with energize_mit, calculate DLC share in each building based on assigned area)
    - stg_building_energy (groupby building and fiscal_year from energy_cdr_
    - stg_dlc_energy_summary (aggregated across building for each DLC and fiscal_year combination)
    - stg_dlc_footprint_capita (allocate campus total for selected categories by DLC employee count)
    - final_footprint_records (DLC/Fiscal_year/Category breakdown of GHG footprint, used for the Pulse API)

## Tests
- Local materialization
- Added checks for unique combination and accepted values


## Screenshots
<img width="788" alt="image" src="https://github.com/user-attachments/assets/7ec1bdd1-52fc-42b8-8858-5caab90463af" />

## What gif best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/4umceEiqTacUsikXv2/giphy.gif?cid=bd3ea57etfk3w4drr6ve9fcwhhv6cy08w8fwquykejtvwdcc&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>
